### PR TITLE
fix: all_ok check for empyt GRangesList (see issue #126)

### DIFF
--- a/R/proteinToX.R
+++ b/R/proteinToX.R
@@ -335,7 +335,7 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
     res <- mapply(
         cds_genome, as(coords_cds, "IRangesList"), as(x, "IRangesList"),
         FUN = function(gnm, cds, prt) {
-            if (is.null(gnm) | !length(gnm)) {
+            if (!length(gnm)) { ## addressed NULL and empty elements
                 GRanges()
             } else {
                 ## Unlist because we'd like to have a GRanges here. Will split
@@ -343,8 +343,9 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
                 maps <- unlist(.to_genome(gnm, cds))
                 ## Don't want to have GRanges names!
                 names(maps) <- NULL
-                mcols(maps)$protein_start <- start(prt)
-                mcols(maps)$protein_end <- end(prt)
+                mcols(maps) <- cbind(mcols(maps),
+                                     protein_start = start(prt),
+                                     protein_end = end(prt))
                 maps[order(maps$exon_rank)]
             }
         })

--- a/R/proteinToX.R
+++ b/R/proteinToX.R
@@ -324,13 +324,13 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
     message("Checking CDS and protein sequence lengths ... ", appendLF = FALSE)
     cds_genome <- .cds_matching_protein(db, cds_genome)
     are_ok <- unlist(lapply(cds_genome, function(z) {
-        if (is(z, "GRangesList"))
+        if (is(z, "GRangesList") & length(z) > 0)
             all(z[[1]]$cds_ok)
         else NA
     }))
+    message(sum(are_ok, na.rm = TRUE), "/", length(are_ok), " OK")
     are_ok <- are_ok[!is.na(are_ok)]
     ## We've got now a list of GRanges
-    message(sum(are_ok), "/", length(are_ok), " OK")
     ## Perform the mapping for each input range with each mapped cds
     res <- mapply(
         cds_genome, as(coords_cds, "IRangesList"), as(x, "IRangesList"),

--- a/R/proteinToX.R
+++ b/R/proteinToX.R
@@ -335,7 +335,7 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
     res <- mapply(
         cds_genome, as(coords_cds, "IRangesList"), as(x, "IRangesList"),
         FUN = function(gnm, cds, prt) {
-            if (is.null(gnm)) {
+            if (is.null(gnm) | !length(gnm)) {
                 GRanges()
             } else {
                 ## Unlist because we'd like to have a GRanges here. Will split

--- a/R/proteinToX.R
+++ b/R/proteinToX.R
@@ -335,7 +335,7 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
     res <- mapply(
         cds_genome, as(coords_cds, "IRangesList"), as(x, "IRangesList"),
         FUN = function(gnm, cds, prt) {
-            if (!length(gnm)) { ## addressed NULL and empty elements
+            if (!length(gnm)) { ## addresses NULL and empty elements
                 GRanges()
             } else {
                 ## Unlist because we'd like to have a GRanges here. Will split


### PR DESCRIPTION
This PR fixes
- the `all_ok` check documented in issue #126 
- the corresponding message that now thrown before filtering those that are ok and takes NAs into account. 
