### PR TITLE
Fix link to ensembldb vignette source

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,4 +10,4 @@
 # `ensembldb`: build and use Ensembl-based annotation packages
 
 For more information please refer to
-the [vignettes/ensembldb.org](vignettes/ensembldb.org) file.
+the [vignettes/ensembldb.org](vignettes/ensembldb.Rmd) file.


### PR DESCRIPTION
Although I think it would be more useful to link directly to the html version at https://jorainer.github.io/ensembldb/articles/ensembldb.html