### PR TITLE
refactor: don't report duplicated tx_id columns (issue #136)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ensembldb
 Type: Package
 Title: Utilities to create and use Ensembl-based annotation databases
-Version: 2.21.1
+Version: 2.21.2
 Authors@R: c(person(given = "Johannes", family = "Rainer",
 	   email = "johannes.rainer@eurac.edu",
 	   role = c("aut", "cre"),
@@ -95,4 +95,4 @@ Collate:
     'zzz.R'
 biocViews: Genetics, AnnotationData, Sequencing, Coverage
 License: LGPL
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0

--- a/R/genomeToX.R
+++ b/R/genomeToX.R
@@ -185,7 +185,8 @@ genomeToProtein <- function(x, db) {
     if (is.null(names(txs)))
         names(txs) <- ""
     prts <- transcriptToProtein(txs, db)
-    mcols(prts) <- cbind(mcols(prts)[, c("tx_id", "cds_ok")], mcols(txs))
+    mcols(prts) <- cbind(mcols(prts)[, c("tx_id", "cds_ok")],
+                         mcols(txs)[, colnames(mcols(txs)) != "tx_id"])
     prts <- split(prts, int_ids)
     names(prts) <- NULL
     ## Prune the result by removing non-mappable regions from each element


### PR DESCRIPTION
- Avoid reporting of duplicated `"tx_id"` column in `genomeToProtein`.