### PR TITLE
Turn regular function proteinToGenome() into S4 method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ensembldb
 Type: Package
 Title: Utilities to create and use Ensembl-based annotation databases
-Version: 2.21.3
+Version: 2.21.4
 Authors@R: c(person(given = "Johannes", family = "Rainer",
 	   email = "johannes.rainer@eurac.edu",
 	   role = c("aut", "cre"),
@@ -45,7 +45,7 @@ Depends:
     R (>= 3.5.0),
     BiocGenerics (>= 0.15.10),
     GenomicRanges (>= 1.31.18),
-    GenomicFeatures (>= 1.29.10),
+    GenomicFeatures (>= 1.49.6),
     AnnotationFilter (>= 1.5.2)
 Suggests:
     BiocStyle,
@@ -95,4 +95,4 @@ Collate:
     'zzz.R'
 biocViews: Genetics, AnnotationData, Sequencing, Coverage
 License: LGPL
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1

--- a/R/proteinToX.R
+++ b/R/proteinToX.R
@@ -175,6 +175,10 @@ proteinToTranscript <- function(x, db, id = "name",
 
 #' @title Map within-protein coordinates to genomic coordinates
 #'
+#' @name proteinToGenome
+#'
+#' @aliases proteinToGenome proteinToGenome,EnsDb-method
+#'
 #' @description
 #'
 #' `proteinToGenome` maps protein-relative coordinates to genomic coordinates
@@ -264,6 +268,10 @@ proteinToTranscript <- function(x, db, id = "name",
 #'
 #' @family coordinate mapping functions
 #'
+#' @seealso \code{\link[GenomicFeatures]{proteinToGenome}} in the
+#'     \pkg{GenomicFeatures} package for methods that operate on a
+#'     TxDb or GRangesList object.
+#'
 #' @author Johannes Rainer based on initial code from Laurent Gatto and
 #'     Sebastian Gibb
 #'
@@ -305,7 +313,8 @@ proteinToTranscript <- function(x, db, id = "name",
 #'
 #' ## The coordinates within the second protein span two exons
 #' res[[2]]
-proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
+setMethod("proteinToGenome", "EnsDb",
+  function(x, db, id = "name", idType = "protein_id") {
     if (missing(x) || !is(x, "IRanges"))
         stop("Argument 'x' is required and has to be an 'IRanges' object")
     if (missing(db) || !is(db, "EnsDb"))
@@ -356,7 +365,7 @@ proteinToGenome <- function(x, db, id = "name", idType = "protein_id") {
             split(z, f = z$protein_id)
         else z
     })
-}
+  })
 
 #' @description Convert within-protein coordinates to transcript (CDS) relative
 #'    coordinates.

--- a/man/proteinToGenome.Rd
+++ b/man/proteinToGenome.Rd
@@ -2,9 +2,10 @@
 % Please edit documentation in R/proteinToX.R
 \name{proteinToGenome}
 \alias{proteinToGenome}
+\alias{proteinToGenome,EnsDb-method}
 \title{Map within-protein coordinates to genomic coordinates}
 \usage{
-proteinToGenome(x, db, id = "name", idType = "protein_id")
+\S4method{proteinToGenome}{EnsDb}(x, db, id = "name", idType = "protein_id")
 }
 \arguments{
 \item{x}{\code{IRanges} with the coordinates within the protein(s). The
@@ -132,6 +133,10 @@ res[[1]]
 res[[2]]
 }
 \seealso{
+\code{\link[GenomicFeatures]{proteinToGenome}} in the
+\pkg{GenomicFeatures} package for methods that operate on a
+TxDb or GRangesList object.
+
 Other coordinate mapping functions: 
 \code{\link{cdsToTranscript}()},
 \code{\link{genomeToProtein}()},


### PR DESCRIPTION
Hi,

In BioC 3.15 `proteinToGenome()` became an S4 generic function defined in the **GenomicFeatures** package, with two methods: a default method (that will typically operate on a TxDb object), and a method that operates on a GRangesList object. See `?GenomicFeatures::proteinToGenome` for the details.

Following this change, the `proteinToGenome()` function defined in the **ensembldb** package needs to be turned into an S4 method that operates on an EnsDb object.

Note that this PR requires **GenomicFeatures** >= 1.49.6 which should become available in BioC 3.16 via `BiocManager::install()` in the next 24-48 hours.

Cheers,
H.